### PR TITLE
Support verifying existing pacts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+tmp/
+node_modules/
+dist/

--- a/addon/-private/pact-test-module.js
+++ b/addon/-private/pact-test-module.js
@@ -9,7 +9,7 @@ import { Promise } from 'rsvp'
 import { uploadInteraction, finalize } from './upload';
 
 export default class PactTestModule extends TestModule {
-  constructor(description, callbacks = {}) {
+  constructor(_, description, callbacks = {}) {
     callbacks.integration = true;
 
     super('pact:-', description, callbacks);
@@ -79,7 +79,7 @@ let uploads = [];
 
 function addUpload(upload) {
   uploads.push(upload);
-  upload.finally(() => uploads.splice(uploads.indexOf(upload), 1));
+  upload.then(() => uploads.splice(uploads.indexOf(upload), 1));
 }
 
 function registerFinalizeCallback() {

--- a/addon/-private/upload.js
+++ b/addon/-private/upload.js
@@ -33,7 +33,7 @@ function post(path, body) {
       }
     })
     .catch((error) => {
-      throw new Error(`[ember-cli-pact] Upload error: ${error.message}`);
+      throw new Error(`[ember-cli-pact] ${error.message}`);
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
         mockProvider: 'mirage',
         providerName: 'provider',
         consumerName: this.project.name(),
-        pactsDirectory: 'pacts'
+        pactsDirectory: 'pacts',
+        mode: process.env.PACT_MODE || (process.env.CI ? 'verify' : 'write')
       }
     };
   },

--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,7 +1,14 @@
 module.exports = {
+  plugins: ['node'],
+  parserOptions: {
+    sourceType: 'script',
+  },
   env: {
-    es6: true,
+    browser: false,
     node: true,
-    browser: false
+    es6: true
+  },
+  rules: {
+    'node/no-unsupported-features': 'error'
   }
 };

--- a/lib/pact-error.js
+++ b/lib/pact-error.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = class PactError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}

--- a/lib/pact-middleware.js
+++ b/lib/pact-middleware.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const TestSession = require('./test-session');
+const PactError = require('./pact-error');
 const bodyParser = require('body-parser');
 const debug = require('debug')('ember-cli-pact:middleware');
 
@@ -25,8 +26,12 @@ module.exports = class PactMiddleware {
         }
         res.sendStatus(204);
       } catch (error) {
-        debug('Error dispatching request: %s', error.message);
-        res.status(500).send(error.message);
+        if (error instanceof PactError) {
+          res.status(error.status).send(error.message);
+        } else {
+          debug('Error dispatching request: %s', error.message);
+          res.status(500).send(error.message);
+        }
       }
     };
   }

--- a/lib/test-session.js
+++ b/lib/test-session.js
@@ -2,7 +2,10 @@
 
 const fs = require('fs-extra');
 const stringify = require('json-stable-stringify');
+const difference = require('lodash/difference');
+const intersection = require('lodash/intersection');
 const debug = require('debug')('ember-cli-pact:test-session');
+const PactError = require('./pact-error');
 
 module.exports = class TestSession {
   constructor(id, config) {
@@ -23,24 +26,55 @@ module.exports = class TestSession {
   finalize() {
     assert(`Can't finalize a session twice`, !this.finalized);
     debug('Finalizing test session');
-
     this.finalized = true;
 
-    let target = this.config.pactsDirectory;
+    if (this.config.mode === 'write') {
+      this._writePacts();
+    } else {
+      this._verifyPacts();
+    }
+  }
 
+  _writePacts() {
+    let target = this.config.pactsDirectory;
     fs.removeSync(target);
     fs.mkdirpSync(target);
 
     for (let provider of this.providerInteractions.keys()) {
-      let interactions = this.providerInteractions.get(provider).sort((a, b) => {
-        assert(`Duplicate interaction name: '${a.description}'`, a.description !== b.description);
-        return a.description < b.description ? -1 : 1;
-      });
-
-      let pact = makePact(this.config.consumerName, provider, interactions);
-
-      fs.writeFileSync(`${target}/${provider}.json`, stringify(pact, { space: 2 }) + '\n');
+      fs.writeFileSync(`${target}/${provider}.json`, this._pactStringFor(provider));
     }
+  }
+
+  _verifyPacts() {
+    let failures = [];
+    let actualProviders = Array.from(this.providerInteractions.keys());
+    let expectedProviders = fs.readdirSync(this.config.pactsDirectory).map(name => name.replace(/\.json$/, ''));
+
+    for (let extra of difference(actualProviders, expectedProviders)) {
+      failures.push(`Unexpected pact: ${extra}.json`);
+    }
+
+    for (let missing of difference(expectedProviders, actualProviders)) {
+      failures.push(`Missing pact: ${missing}.json`);
+    }
+
+    for (let provider of intersection(expectedProviders, actualProviders)) {
+      let contents = this._pactStringFor(provider);
+      if (fs.readFileSync(`${this.config.pactsDirectory}/${provider}.json`, 'utf-8') !== contents) {
+        failures.push(`Changed pact: ${provider}.json`);
+      }
+    }
+
+    if (failures.length) {
+      let message = `Verification failed:\n  - ${failures.join('\n  - ')}`;
+      throw new PactError(409, message);
+    }
+  }
+
+  _pactStringFor(provider) {
+    let interactions = sortInteractions(this.providerInteractions.get(provider));
+    let pact = makePact(this.config.consumerName, provider, interactions);
+    return stringify(pact, { space: 2 }) + '\n';
   }
 
   _interactionsFor(provider) {
@@ -66,6 +100,13 @@ function makePact(consumer, provider, interactions) {
       }
     }
   };
+}
+
+function sortInteractions(interactions) {
+  return interactions.sort((a, b) => {
+    assert(`Duplicate interaction name: '${a.description}'`, a.description !== b.description);
+    return a.description < b.description ? -1 : 1;
+  });
 }
 
 function assert(message, condition) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "repository": "salsify/ember-cli-pact",
   "scripts": {
     "build": "ember build",
+    "lint": "eslint .",
     "start": "ember server",
     "test": "ember try:each"
   },
@@ -21,7 +22,9 @@
     "body-parser": "^1.18.2",
     "debug": "^3.1.0",
     "ember-cli-babel": "^6.3.0",
-    "json-stable-stringify": "^1.0.1"
+    "ember-uuid": "^1.0.0",
+    "json-stable-stringify": "^1.0.1",
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",
@@ -42,10 +45,11 @@
     "ember-data": "^2.16.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-inflector": "^2.0.1",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0",
-    "ember-uuid": "^1.0.0",
+    "eslint-plugin-node": "^5.2.0",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -43,9 +43,5 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
   }
 
-  if (environment === 'production') {
-
-  }
-
   return ENV;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,7 +2600,7 @@ ember-get-config@0.2.1:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^5.1.6"
 
-ember-inflector@^2.0.0:
+ember-inflector@^2.0.0, ember-inflector@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.0.1.tgz#e9ac469ffa17992a43276bb1c9b8d87992b10d37"
   dependencies:
@@ -2836,6 +2836,15 @@ escape-html@~1.0.3:
 escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+eslint-plugin-node@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.0.tgz#e1efca04a385516cff3f2f04027ce8c5ae6db749"
+  dependencies:
+    ignore "^3.3.3"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "5.3.0"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -5399,6 +5408,10 @@ sane@^1.1.1, sane@^1.4.1, sane@^1.6.0:
     minimist "^1.1.1"
     walker "~1.0.5"
     watch "~0.10.0"
+
+semver@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.4.1"


### PR DESCRIPTION
Now supports either writing out new pacts or verifying the existing ones. Allows explicitly specifying a mode via the `PACT_MODE` environment variable, but defaults to `verify` in CI and `write` otherwise.