### PR TITLE
changing `pact-specification` to `pactSpecification`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ After running this test, a file `my-api.json` capturing the interaction would be
     }
   ],
   "metadata": {
-    "pact-specification": {
+    "pactSpecification": {
       "version": "3.0.0"
     }
   }

--- a/lib/test-session.js
+++ b/lib/test-session.js
@@ -97,7 +97,7 @@ function makePact(consumer, provider, version, interactions) {
     consumer: { name: consumer },
     interactions: interactions,
     metadata: {
-      'pact-specification': {
+      'pactSpecification': {
         version: standardizeVersionNumber(version),
       }
     }

--- a/pacts/departments-server.json
+++ b/pacts/departments-server.json
@@ -59,7 +59,7 @@
     }
   ],
   "metadata": {
-    "pact-specification": {
+    "pactSpecification": {
       "version": "3.0.0"
     }
   },

--- a/pacts/non-rest-server.json
+++ b/pacts/non-rest-server.json
@@ -42,7 +42,7 @@
     }
   ],
   "metadata": {
-    "pact-specification": {
+    "pactSpecification": {
       "version": "3.0.0"
     }
   },

--- a/pacts/test-provider.json
+++ b/pacts/test-provider.json
@@ -342,7 +342,7 @@
     }
   ],
   "metadata": {
-    "pact-specification": {
+    "pactSpecification": {
       "version": "3.0.0"
     }
   },

--- a/pacts/test-v2-provider.json
+++ b/pacts/test-v2-provider.json
@@ -44,7 +44,7 @@
     }
   ],
   "metadata": {
-    "pact-specification": {
+    "pactSpecification": {
       "version": "2.0.0"
     }
   },


### PR DESCRIPTION
While ember-cli-pact's implementation is technically correct, it has integration issues with Ruby's [pact-support](https://github.com/pact-foundation/pact-support/issues/62) library. I have raised an issue in that project as well, but it seems like it may be preferable for ember-cli-pact to simply use the more common `pactSpecification` key instead, especially since most of the keys in the pact document are camelCased? This PR does that work and makes the libraries compatible.