### PR TITLE
Use `providerName` and `consumerName` respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ module('Pact | People', function(hooks) {
   setupPact(hooks, {
     // Specify the names of the provider and consumer whose interactions are being set up.
     // Normally these values would be defaulted from global configuration for your app.
-    provider: 'my-api',
-    consumer: 'my-app'
+    providerName: 'my-api',
+    consumerName: 'my-app'
   });
 
   test('locating a person by ID', async function(assert) {


### PR DESCRIPTION
The current documentation for module-specific configuration is causing the addon to throw an error because the configuration key names are missing the `Name` suffix.