### PR TITLE
Add pact broker token to publish arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ There are several ways to configure upload process:
     defaults to the version in `package.json`)
   + `--broker-username` (username to access pact broker)
   + `--broker-password` (password to access pact broker)
+  + `--broker-token` (token to access pact broker)
   + `--tags` (a comma-separated string with tags for pacts)
 + via `.env` file
   + `EMBER_CLI_PACT_PATH` (custom path to pact files)
@@ -358,6 +359,7 @@ There are several ways to configure upload process:
   + `EMBER_CLI_PACT_CONSUMER_VERSION` (the version of your application)
   + `EMBER_CLI_PACT_BROKER_USERNAME` (username to access pact broker)
   + `EMBER_CLI_PACT_BROKER_PASSWORD` (password to access pact broker)
+  + `EMBER_CLI_PACT_BROKER_TOKEN` (token to access pact broker)
   + `EMBER_CLI_PACT_TAGS` (a comma-separated string with tags for pacts)
 + via `proccess.env`
   + `process.env.EMBER_CLI_PACT_PATH` (custom path to pact files)
@@ -365,6 +367,7 @@ There are several ways to configure upload process:
   + `process.env.EMBER_CLI_PACT_CONSUMER_VERSION` (the version of your application)
   + `process.env.EMBER_CLI_PACT_BROKER_USERNAME` (username to access pact broker)
   + `process.env.EMBER_CLI_PACT_BROKER_PASSWORD` (password to access pact broker)
+  + `process.env.EMBER_CLI_PACT_BROKER_TOKEN` (token to access pact broker)
   + `process.env.EMBER_CLI_PACT_TAGS` (a comma-separated string with tags for pacts)
 
 `ember-cli-pact` uses [dotenv](https://github.com/motdotla/dotenv) for

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -18,6 +18,7 @@ module.exports = {
     { name: 'consumer-version', type: String, description: 'A string containing a semver-style version, e.g. 1.0.0.', default: '' },
     { name: 'broker-username', type: String, description: 'Username for Pact Broker basic authentication.', default: '' },
     { name: 'broker-password', type: String, description: 'Password for Pact Broker basic authentication.', default: '' },
+    { name: 'broker-token', type: String, description: 'Token for Pact Broker token authentication.', default: '' },
     { name: 'tags', type: String, description: 'A comma-separated string to tag the Pacts being published.', default: '' },
   ],
 
@@ -41,6 +42,7 @@ module.exports = {
       broker: process.env.EMBER_CLI_PACT_BROKER,
       brokerUsername: process.env.EMBER_CLI_PACT_BROKER_USERNAME,
       brokerPassword: process.env.EMBER_CLI_PACT_BROKER_PASSWORD,
+      brokerToken: process.env.EMBER_CLI_PACT_BROKER_TOKEN,
       tags: process.env.EMBER_CLI_PACT_TAGS
     };
     let mergedConfig = Object.assign({}, config, commandLineOptions);
@@ -51,6 +53,7 @@ module.exports = {
       pactBroker: mergedConfig.broker || config.broker,
       pactBrokerUsername: mergedConfig.brokerUsername,
       pactBrokerPassword: mergedConfig.brokerPassword,
+      pactBrokerToken: mergedConfig.brokerToken,
       tags: mergedConfig.tags ? mergedConfig.tags.split(',') : []
     };
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -45,16 +45,18 @@ module.exports = {
       brokerToken: process.env.EMBER_CLI_PACT_BROKER_TOKEN,
       tags: process.env.EMBER_CLI_PACT_TAGS
     };
-    let mergedConfig = Object.assign({}, config, commandLineOptions);
+
+    const pactPath = (config) => config.path ? [config.path] : null
+    const splitTags = (config) => config.tags ? config.tags.split(',') : null
 
     let resultingConfig = {
-      pactFilesOrDirs: mergedConfig.path ? [mergedConfig.path] : [`${projectRoot}/pacts`],
-      consumerVersion: mergedConfig.version || projectVersion,
-      pactBroker: mergedConfig.broker || config.broker,
-      pactBrokerUsername: mergedConfig.brokerUsername,
-      pactBrokerPassword: mergedConfig.brokerPassword,
-      pactBrokerToken: mergedConfig.brokerToken,
-      tags: mergedConfig.tags ? mergedConfig.tags.split(',') : []
+      pactFilesOrDirs: pactPath(commandLineOptions) || pactPath(config) || [`${projectRoot}/pacts`],
+      consumerVersion: commandLineOptions.version || config.version || projectVersion,
+      pactBroker: commandLineOptions.broker || config.broker || '',
+      pactBrokerUsername: commandLineOptions.brokerUsername || config.brokerUsername || '',
+      pactBrokerPassword: commandLineOptions.brokerPassword || config.brokerPassword || '',
+      pactBrokerToken: commandLineOptions.brokerToken || config.brokerToken || '',
+      tags: splitTags(commandLineOptions) || splitTags(config) || []
     };
 
     if (!resultingConfig.pactBroker) {

--- a/node-tests/unit/publish-command-test.js
+++ b/node-tests/unit/publish-command-test.js
@@ -34,11 +34,14 @@ describe('Publish Command', function() {
       expect(true).to.equal(true, 'publishing of pacts is enabled');
     };
 
-    publishCommand.run.call(contextFor('publish'));
+    publishCommand.run.call(contextFor('publish'), {});
   });
 
   it('generates publish options in the right order: command line takes precedence', function() {
     process.env.EMBER_CLI_PACT_BROKER = 'http://localhost:1235/';
+    process.env.EMBER_CLI_PACT_BROKER_USERNAME = 'username';
+    process.env.EMBER_CLI_PACT_BROKER_PASSWORD = 'password';
+    process.env.EMBER_CLI_PACT_BROKER_TOKEN = 'abcdefg123';
 
     let result = publishCommand.getPublishOptions('great-app', '1.2.3', {
       path: 'great-app/lib/pacts',
@@ -53,9 +56,9 @@ describe('Publish Command', function() {
       pactFilesOrDirs: ['great-app/lib/pacts'],
       consumerVersion: '2.2.3',
       pactBroker: 'http://localhost:1235/',
-      pactBrokerUsername: '',
-      pactBrokerPassword: '',
-      pactBrokerToken: '',
+      pactBrokerUsername: 'username',
+      pactBrokerPassword: 'password',
+      pactBrokerToken: 'abcdefg123',
       tags: ['release']
     });
   });

--- a/node-tests/unit/publish-command-test.js
+++ b/node-tests/unit/publish-command-test.js
@@ -13,6 +13,7 @@ describe('Publish Command', function() {
     consumerVersion: '',
     brokerUsername: '',
     brokerPassword: '',
+    brokerToken: '',
     tags: ''
   };
 
@@ -22,6 +23,7 @@ describe('Publish Command', function() {
     delete process.env.EMBER_CLI_PACT_BROKER;
     delete process.env.EMBER_CLI_PACT_BROKER_USERNAME;
     delete process.env.EMBER_CLI_PACT_BROKER_PASSWORD;
+    delete process.env.EMBER_CLI_PACT_BROKER_TOKEN;
     delete process.env.EMBER_CLI_PACT_TAGS;
   });
 
@@ -43,6 +45,7 @@ describe('Publish Command', function() {
       version: '2.2.3',
       brokerUsername: '',
       brokerPassword: '',
+      brokerToken: '',
       tags: 'release'
     });
 
@@ -52,6 +55,7 @@ describe('Publish Command', function() {
       pactBroker: 'http://localhost:1235/',
       pactBrokerUsername: '',
       pactBrokerPassword: '',
+      pactBrokerToken: '',
       tags: ['release']
     });
   });
@@ -67,6 +71,7 @@ describe('Publish Command', function() {
       pactBroker: 'http://localhost:1235/',
       pactBrokerUsername: '',
       pactBrokerPassword: '',
+      pactBrokerToken: '',
       tags: []
     });
   });
@@ -82,6 +87,7 @@ describe('Publish Command', function() {
       pactBroker: 'http://localhost:1235/',
       pactBrokerUsername: '',
       pactBrokerPassword: '',
+      pactBrokerToken: '',
       tags: []
     });
   });


### PR DESCRIPTION
As of version 8.4.x the `pact-foundation/pact-node` package is able to authenticate with a broker using token based authentication. This provides the means to pass a token through the ember addon to the `pact-node` package.

Additionally `Object.assign` has been removed in favour of checking the values from the environment and command line separately. When `Object.assign` is used with the command line options the default values (typically empty string) are used in favour of the values passed in the environment.

```javascript
let commandLineOptions = { hello: '' }
let config = { hello: 'world' }

Object.assign({}, config, commandLineOptions)
===> { hello: '' }
```

This is not the intended output. Instead using the `||` operator results in the intended output due to the empty string being falsey in JavaScript

```javascript
let commandLineOptions = { hello: '' }
let config = { hello: 'world' }

console.log(commandLineOptions.hello || config.hello || '')
===> 'world'
```

If however the command line options are given a specific value then they still take precedence

```javascript
let commandLineOptions = { hello: 'panda' }
let config = { hello: 'world' }

console.log(commandLineOptions.hello || config.hello || '')
===> 'panda'
```